### PR TITLE
Update keyword for rq.Queue.enqueue()

### DIFF
--- a/dockermirror/api/__init__.py
+++ b/dockermirror/api/__init__.py
@@ -45,7 +45,7 @@ def create_archive():
     with Connection(conn):
         q = Queue('default')
         job = q.enqueue(save_images, Path(app.config['OUTPUT_DIR']), images,
-                        timeout='1h', ttl='24h', result_ttl='7d')
+                        job_timeout='1h', ttl='24h', result_ttl='7d')
 
     response = {
         'job_id': job.get_id(),

--- a/worker-requirements.txt
+++ b/worker-requirements.txt
@@ -1,4 +1,4 @@
 flask
 docker
 redis
-rq
+rq>=1.0


### PR DESCRIPTION
Keyword `timeout` was deprecated in version 1.0 of `rq`.

https://github.com/rq/rq/releases/tag/v1.0